### PR TITLE
Fixes bug in certain themes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,4 +3,5 @@ img.emoji {
   width: 1em;
   margin: 0 0.05em 0 0.1em;
   vertical-align: -0.1em;
+  display: inline-block;
 }


### PR DESCRIPTION
In certain themes, twitter style emojis cause line breaks due to how `img`s are displayed. This should fix that issue.