### PR TITLE
Fix blurry Twemoji

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@ img.emoji {
   margin: 0 0.05em 0 0.1em;
   vertical-align: -0.1em;
   display: inline-block;
+  image-rendering: -webkit-optimize-contrast;
 }
 
 .emoji-mart,


### PR DESCRIPTION
Modified `image-rendering` CSS property to render Twemoji crisper

## Before

![image](https://user-images.githubusercontent.com/65048459/184510808-897fdde9-c4b6-4164-a4cd-4065a71e025b.png)

## After

![image](https://user-images.githubusercontent.com/65048459/184510817-743d005d-d507-4c71-b845-f266df1f21ec.png)