### PR TITLE
:bug: fix: wait for modal close before emoji insert (#39)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ import twemoji from 'twemoji'
 
 import EmojiToolbar from './ui/EmojiToolbar';
 
+const DEF_DELAY = 1000;
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms || DEF_DELAY));
+}
+
 class EmojiModal extends Modal {
   private div: HTMLElement;
   private reactComponent: React.ReactElement;
@@ -12,8 +17,9 @@ class EmojiModal extends Modal {
   constructor(app: App, theme: str) {
     super(app)
     this.reactComponent = React.createElement(EmojiToolbar, {
-      "onSelect": (emoji) => {
+      "onSelect": async (emoji: any) => {
         this.close()
+        await sleep(10)
         document.execCommand('insertText', false, emoji.native)
       },
       "onClose": () => {


### PR DESCRIPTION
Short-term fix to address issue where the cursor momentarily appears at the top of the edited file when calling `close()` on a modal.